### PR TITLE
(MAINT) Place Example Usage in yaml code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # Leanpub Preview Action
+
 This action triggers preview processing in LeanPub
 
 ## Inputs
+
 ### `api_key`
+
 **Required** The api secret for your LeanPub account
 
 ### `book_slug`
-Your book SLUG. It's the part of the URL for your book after https://leanpub.com/. E.g. if your book is found at https://leanpub.com/your_book, then your book's slug is your_book.
+
+Your book SLUG.
+It's the part of the URL for your book after https://leanpub.com/.
+E.g. if your book is found at https://leanpub.com/your_book, then your book's slug is your_book.
 
 ## Example usage
 
+```yaml
 uses: robert-matusewicz/leanpub-preview-action@v1.0.0
 with:
     api_key: <YOUR API KEY>
     book_slug: <YOUR BOOK SLUG>
+```


### PR DESCRIPTION
This commit updates the example usage section to display the usage in a YAML code block to ensure it displays correctly.

It also updates the whitespace in the document per markdown-lint guidelines (one line of space around each header) and to use semantic line feeds for clarity and future editing ease.